### PR TITLE
Configura build para usar as configuração de publicação

### DIFF
--- a/.github/workflows/pelican.yml
+++ b/.github/workflows/pelican.yml
@@ -15,3 +15,4 @@ jobs:
     - uses: nelsonjchen/gh-pages-pelican-action@0.1.5
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        PELICAN_CONFIG_FILE: publishconf.py

--- a/publishconf.py
+++ b/publishconf.py
@@ -7,7 +7,7 @@ sys.path.append(os.curdir)
 from pelicanconf import *
 
 # If your site is available via HTTPS, make sure SITEURL begins with https://
-SITEURL = ''
+SITEURL = 'https://bugelseif.github.io/website/'
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'


### PR DESCRIPTION
Ajusta CI para usar as configurações em `publishconf.py`. Isso habilitará o [feed Atom](https://pt.wikipedia.org/wiki/Atom), permitindo receber notificações de novos artigos em leitores para isso, como o [Liferea](https://lzone.de/liferea/) ou [Feedly](https://feedly.com/), bastando adicionar o link https://bugelseif.github.io/website/feeds/all.atom.xml no leitor, ou trocar `all` pela catogoria desejada.